### PR TITLE
Disable tablerates option offered if no matches

### DIFF
--- a/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
+++ b/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
@@ -564,6 +564,9 @@ class TableRatesShippingMethod extends comShippingMethod
             return false;
         }
 
+        $options = $this->getMatchingOptions($shipment);
+        return count($options);
+
         return true;
     }
 }

--- a/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
+++ b/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
@@ -449,6 +449,30 @@ class TableRatesShippingMethod extends comShippingMethod
         return $options;
     }
 
+    /**
+     * Filter a set of options by the weight condition; options should already have been filtered down by destination.
+     *
+     * @param array                                    $options
+     * @param \PhpUnitsOfMeasure\PhysicalQuantity\Mass $weight
+     *
+     * @return array
+     */
+    private function filterWeightMatchingOptions(array $options, Mass $weight) : array
+    {
+      $validOptions = [];
+      foreach ($options as $option) {
+        try {
+          $optWeight = new Mass((float)$option['condition'], $this->getProperty('weight_unit', 'g'));
+          if ($weight->subtract($optWeight)->toUnit($this->getProperty('weight_unit', 'g')) > 0) {
+            $validOptions[] = $option;
+          }
+        }
+        catch (Exception $e) {}
+      }
+
+      return $validOptions;
+    }
+
 
     /**
      * Utility to convert 3 character country codes to the 2 character country codes

--- a/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
+++ b/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
@@ -487,7 +487,7 @@ class TableRatesShippingMethod extends comShippingMethod
       foreach ($options as $option) {
         try {
           $optWeight = new Mass((float)$option['condition'], $this->getProperty('weight_unit', 'g'));
-          if ($weight->subtract($optWeight)->toUnit($this->getProperty('weight_unit', 'g')) > 0) {
+          if ($weight->subtract($optWeight)->toUnit($this->getProperty('weight_unit', 'g')) >= 0) {
             $validOptions[] = $option;
           }
         }

--- a/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
+++ b/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
@@ -356,14 +356,14 @@ class TableRatesShippingMethod extends comShippingMethod
 
         $options = $this->getMatchingOptions($shipment);
 
-        switch ($this->getProperty('condition', 'weight')) {
-            case 'weight':
-                return $this->getMatchForWeight($options, $shipment->getWeight());
-//            case 'price':
-//                return $this->getMatchForPrice($options, $shipment->getWeight());
-//            case 'items':
-//                return $this->getMatchForItems($options, $shipment->getWeight());
+        /* TODO: In the past, not having a matching option would NOT trigger parent::getPriceForShipment; now it does. But also,
+            if there are no matching options, it won't even show up in the list anyway now. The To Do here is to make sure that's
+            what we want.
+        */
+        if(count($options)) {
+          return $this->getPriceFromOptions($options);
         }
+
         return parent::getPriceForShipment($shipment);
     }
 

--- a/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
+++ b/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
@@ -509,6 +509,25 @@ class TableRatesShippingMethod extends comShippingMethod
       return $validOptions;
     }
 
+    /**
+     * Get the price value (in int form) from a set of available options
+     *
+     * @param array $options
+     *
+     * @return int
+     */
+    private function getPriceFromOptions(array $options) : int
+    {
+      $price = 0;
+      // TableRates expects to use the last option, so just get that
+      if(count($options)) {
+        $option = $options[array_key_last($options)];
+        $price = (int)((float)$option['price'] * 100);
+      }
+
+      return $price;
+    }
+
 
     /**
      * Utility to convert 3 character country codes to the 2 character country codes

--- a/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
+++ b/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
@@ -358,7 +358,7 @@ class TableRatesShippingMethod extends comShippingMethod
         $country = $address->get('country');
         $state = $address->get('state');
         $zip = $address->get('zip');
-        $options = $this->getMatchingOptions($data, $country, $state, $zip);
+        $options = $this->getDestinationOptions($data, $country, $state, $zip);
 
         switch ($this->getProperty('condition', 'weight')) {
             case 'weight':
@@ -403,7 +403,7 @@ class TableRatesShippingMethod extends comShippingMethod
      * @param string $actualZip
      * @return array
      */
-    public function getMatchingOptions($data, $actualCountry, $actualState, $actualZip)
+    public function getDestinationOptions($data, $actualCountry, $actualState, $actualZip)
     {
         $options = [];
         $lines = explode("\n", $data);

--- a/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
+++ b/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
@@ -346,20 +346,8 @@ class TableRatesShippingMethod extends comShippingMethod
         if (!$order) {
             return parent::getPriceForShipment($shipment);
         }
-        $address = $order->getShippingAddress();
-        if (!$address) {
-            $address = $order->getExpectedAddress();
-        }
-        if (!$address) {
-            return parent::getPriceForShipment($shipment);
-        }
 
         $options = $this->getMatchingOptions($shipment);
-
-        /* TODO: In the past, not having a matching option would NOT trigger parent::getPriceForShipment; now it does. But also,
-            if there are no matching options, it won't even show up in the list anyway now. The To Do here is to make sure that's
-            what we want.
-        */
         if(count($options)) {
           return $this->getPriceFromOptions($options);
         }

--- a/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
+++ b/core/components/commerce_tablerates/model/commerce_tablerates/tableratesshippingmethod.class.php
@@ -347,7 +347,7 @@ class TableRatesShippingMethod extends comShippingMethod
             return parent::getPriceForShipment($shipment);
         }
 
-        $options = $this->getMatchingOptions($shipment);
+        $options = $this->getFilteredOptions($shipment);
         if(count($options)) {
           return $this->getPriceFromOptions($options);
         }
@@ -385,7 +385,7 @@ class TableRatesShippingMethod extends comShippingMethod
    *
    * @return array
    */
-  public function getMatchingOptions(comOrderShipment $shipment) : array
+  public function getFilteredOptions(comOrderShipment $shipment) : array
     {
       // Grab the order and shipping address.
       $order = $shipment->getOrder();
@@ -405,15 +405,15 @@ class TableRatesShippingMethod extends comShippingMethod
       $country = $address->get('country');
       $state = $address->get('state');
       $zip = $address->get('zip');
-      $options = $this->getDestinationOptions($data, $country, $state, $zip);
+      $options = $this->getMatchingOptions($data, $country, $state, $zip);
 
       switch ($this->getProperty('condition', 'weight')) {
         case 'weight':
-          return $this->filterWeightMatchingOptions($options, $shipment->getWeight());
+          return $this->filterWeightOptions($options, $shipment->getWeight());
 //            case 'price':
-//                return $this->filterPriceMatchingOptions($options, $shipment->getWeight());
+//                return $this->filterPriceOptions($options, $shipment->getWeight());
 //            case 'items':
-//                return $this->filterItemMatchingOptions($options, $shipment->getWeight());
+//                return $this->filterItemOptions($options, $shipment->getWeight());
       }
 
       return $options;
@@ -427,12 +427,12 @@ class TableRatesShippingMethod extends comShippingMethod
      * @param string $actualZip
      * @return array
      */
-    public function getDestinationOptions($data, $actualCountry, $actualState, $actualZip)
+    public function getMatchingOptions($data, $actualCountry, $actualState, $actualZip)
     {
         $options = [];
         $lines = explode("\n", $data);
         foreach ($lines as $line) {
-            list($countryCode, $state, $zip, $condition, $price) = array_map('trim', explode(',', $line));
+            [$countryCode, $state, $zip, $condition, $price] = array_map('trim', explode(',', $line));
             if (strlen($countryCode) === 3) {
                 $countryCode = $this->convertCountryThreeToTwo($countryCode);
             }
@@ -481,7 +481,7 @@ class TableRatesShippingMethod extends comShippingMethod
      *
      * @return array
      */
-    private function filterWeightMatchingOptions(array $options, Mass $weight) : array
+    private function filterWeightOptions(array $options, Mass $weight) : array
     {
       $validOptions = [];
       foreach ($options as $option) {
@@ -552,9 +552,7 @@ class TableRatesShippingMethod extends comShippingMethod
             return false;
         }
 
-        $options = $this->getMatchingOptions($shipment);
+        $options = $this->getFilteredOptions($shipment);
         return count($options);
-
-        return true;
     }
 }

--- a/test/TableRatesTest.php
+++ b/test/TableRatesTest.php
@@ -119,7 +119,7 @@ SWE,*,*,1651.0000,27.0000';
     {
         /** @var \TableRatesShippingMethod $method */
         $method = $this->adapter->newObject('TableRatesShippingMethod');
-        $actual = $method->getMatchingOptions($csv, $country, $state, $zip);
+        $actual = $method->getDestinationOptions($csv, $country, $state, $zip);
         self::assertEquals($expected, $actual);
     }
 

--- a/test/TableRatesTest.php
+++ b/test/TableRatesTest.php
@@ -119,7 +119,7 @@ SWE,*,*,1651.0000,27.0000';
     {
         /** @var \TableRatesShippingMethod $method */
         $method = $this->adapter->newObject('TableRatesShippingMethod');
-        $actual = $method->getDestinationOptions($csv, $country, $state, $zip);
+        $actual = $method->getMatchingOptions($csv, $country, $state, $zip);
         self::assertEquals($expected, $actual);
     }
 


### PR DESCRIPTION
This PR will make it so that a TableRates shipping option is not offered if there are no matches within the price configuration. 

Current behavior is that, if there are no matches, the TableRates option will still be given to customers and the price will be set by the Price field in the Pricing tab. 

This seems somewhat confusing to me; I'd expect that _either_ the TableRates tab is actually REPLACING the Pricing tab or the price on the Pricing tab is _added_ to whatever price is found in the TableRates tab. It also doesn't provide any way for a TableRates shipping option to be disabled if  no rate applies (i.e., we only want to offer this method within a certain country / state /zip code / etc.)

To preserve backwards compatibility, a radio option could be added:
- [x] Use price from Pricing tab as default if no option above applies
- [ ] Disable shipping method if no option above applies

If we default to the first option, then the current behavior would be preserved. This PR _does not_ include this field at this time.

Finally, this PR also addresses issue #4, so that the difference between minimum and actual weight is checked with `>=`, meaning that, for example, a 1kg shipment would meet a 1kg minimum weight.